### PR TITLE
Fix build failures

### DIFF
--- a/picturedrocks/markers/mutualinformation/infoset.py
+++ b/picturedrocks/markers/mutualinformation/infoset.py
@@ -404,7 +404,8 @@ def _sparse_entropy_wrt(
                 i,
             )
             for i in range(n_feats)
-        ]
+        ],
+        dtype=np.float64
     )
     return hs
 

--- a/picturedrocks/markers/mutualinformation/infoset.py
+++ b/picturedrocks/markers/mutualinformation/infoset.py
@@ -83,7 +83,7 @@ def quantile_discretize(X, k=5):
     return newX
 
 
-@nb.jitclass(
+@nb.experimental.jitclass(
     [
         ("has_y", nb.bool_),
         ("X", nb.int64[:, :]),


### PR DESCRIPTION
Two numba changes seem to have broken tests:
- somehow numba wasn't inferring the dtype of entropy to be float
- numba moved jitclass to experimental